### PR TITLE
improves accuracy of type declarations (#8)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,9 +5,9 @@ declare module 'invisible-grecaptcha' {
 declare namespace invisibleGrecaptcha {
   interface Options {
     locale?: string
-    position?: string
+    position?: 'bottomright' | 'bottomleft' | 'inline'
   }
 
-  function execute(sitekey: string, options: Options): string
-  function destroy()
+  function execute(sitekey: string, options?: Options): string
+  function destroy(): void
 }


### PR DESCRIPTION
* changes `Options.position` to a string literal type
* makes `execute()`'s `options` parameter optional
* specifies `destroy()`'s return type to be `void` to silence compiler warnings about it being `any`